### PR TITLE
Fixed issue with duplicate names in the user list

### DIFF
--- a/static/assets/js/message.js
+++ b/static/assets/js/message.js
@@ -50,6 +50,9 @@ nameInput.addEventListener("keyup", function(event) {
 
 socket.on("updateUsers", data => {
 
+  // Clear the user list as the server sends the full user list
+  userList.innerHTML = "";
+
   data.forEach(user => {
     
     userList.innerHTML += "<p>" + user + "</p>"


### PR DESCRIPTION
Simple fix that prevents the names in the user list being duplicated every time someone joins. 